### PR TITLE
Refactor authentication context and API: update user permissions to u…

### DIFF
--- a/client/src/autherization/authApi.ts
+++ b/client/src/autherization/authApi.ts
@@ -3,19 +3,18 @@ import Configuration from '../configuration';
 
 // Base API URL
 const API_URL = Configuration.backendApiUrl;
-
-// Types
-interface UserInfo {
-  sub: string;
-  email?: string;
-  name?: string;
-  [key: string]: any;
+interface AuthData {
+    sub: string;
+    email?: string;
+    name?: string;
+    [key: string]: any;
+  userPermissions: PermissionObject[]; // Match the type in AuthContext
+  userMandates: any[];
 }
 
-interface AuthData {
-  userData: UserInfo;
-  userPermissions: string[];
-  userMandates: any[];
+interface PermissionObject {
+  id: string;
+  scope: string | null;
 }
 
 /**

--- a/client/src/components/LinkCreator.tsx
+++ b/client/src/components/LinkCreator.tsx
@@ -24,12 +24,6 @@ interface ApiError {
   message: string;
 }
 
-interface Mandate {
-  id: string;
-  role: string;
-  // Add other properties if needed
-}
-
 // Styles
 const styles = {
   root: {
@@ -64,8 +58,8 @@ interface LinkCreatorProps {
   desc?: string | ReactNode;
   custom?: boolean;
   disabled?: boolean;
-  userMandates?: Mandate[];
-  showAdvancedOptions?: boolean; // New prop to control visibility of advanced options
+  userGroups?: string[]; // Changed from userMandates to userGroups which are strings
+  showAdvancedOptions?: boolean;
 }
 
 const LinkCreator: React.FC<LinkCreatorProps> = ({
@@ -73,7 +67,7 @@ const LinkCreator: React.FC<LinkCreatorProps> = ({
   desc = "Klistra in en länk för att förkorta den.",
   custom = false,
   disabled = false,
-  userMandates = [],
+  userGroups = [], // Changed from userMandates
   showAdvancedOptions = false
 }) => {
   // Get userData from auth context
@@ -85,7 +79,7 @@ const LinkCreator: React.FC<LinkCreatorProps> = ({
     custom, 
     disabled,
     showAdvancedOptions,
-    userMandatesLength: Array.isArray(userMandates) ? userMandates.length : 'not array'
+    userMandatesLength: Array.isArray(userGroups) ? userGroups.length : 'not array'
   });
   
   // State management
@@ -194,17 +188,13 @@ const LinkCreator: React.FC<LinkCreatorProps> = ({
   };
 
   // Prepare data for the Select component from the Mandate objects
-  const mandateSelectData = Array.isArray(userMandates) 
-    ? userMandates
-        .filter(m => m && m.id && m.role) // Filter out any invalid mandates
-        .map((m) => ({
-          label: String(m.role), // Ensure label is a string
-          value: String(m.id),   // Ensure value is a string
-        }))
-    : [];
+  const groupSelectData = userGroups.map(group => ({
+    label: group,
+    value: group
+  }));
 
-  // Check if we should show the mandate selector
-  const hasValidMandates = mandateSelectData.length > 0;
+  // Check if we should show the group selector
+  const hasGroups = groupSelectData.length > 0;
 
   return (
     <Box style={styles.root}>
@@ -274,16 +264,16 @@ const LinkCreator: React.FC<LinkCreatorProps> = ({
         {/* Advanced options section - only visible with permissions */}
         {showAdvancedOptions && (
           <>
-            {/* Mandate selector - only visible if user has mandates */}
-            {hasValidMandates && (
+            {/* Group selector - only visible if user has groups */}
+            {hasGroups && (
               <Select
-                label="Koppla till mandat (valfritt)"
-                placeholder="Välj mandat"
-                data={mandateSelectData}
+                label="Koppla till grupp (valfritt)"
+                placeholder="Välj grupp"
+                data={groupSelectData}
                 searchable
                 clearable
                 style={styles.formControl}
-                {...form.getInputProps("mandate")}
+                {...form.getInputProps("mandate")} // Reuse the mandate field for group
                 disabled={fetching || disabled}
               />
             )}

--- a/client/src/views/Home.tsx
+++ b/client/src/views/Home.tsx
@@ -11,9 +11,10 @@ import { useAuth } from "../autherization/useAuth.ts";
 const Home = () => {
   const { 
     hasToken, 
-    userMandates, 
-    userPermissions, 
-    isAdmin,
+    userPermissions,
+    customLinks,
+    manageLinks,
+    mandateGroups,
     refreshAuthData
   } = useAuth();
   
@@ -23,14 +24,15 @@ const Home = () => {
   }, []);
   
   // Check if user can create custom links
-  const canCreateCustomLinks = 
-    isAdmin || 
-    (Array.isArray(userPermissions) && userPermissions.length > 0) ||
-    (Array.isArray(userMandates) && userMandates.some(mandate => mandate?.id && mandate?.role));
+  const canCreateCustomLinks = customLinks;
+
+  const canManageLinks = manageLinks;
   
-  console.log("Home render - Can create custom links:", canCreateCustomLinks);
   console.log("User permissions:", userPermissions);
-  console.log("User mandates:", userMandates);
+  console.log("User groups:", mandateGroups);
+  console.log("User can create custom links:", customLinks);
+  console.log("User has token:", hasToken);
+  console.log("User can manage all links:", canManageLinks);
   
   return (
     <>
@@ -81,8 +83,8 @@ const Home = () => {
                     </>
                 }
                 custom={canCreateCustomLinks} // Only show custom field if user has permission
-                userMandates={userMandates || []}
-                showAdvancedOptions={canCreateCustomLinks} // New prop to control visibility of advanced options
+                userGroups={mandateGroups || []}
+                showAdvancedOptions={(mandateGroups && mandateGroups.length > 0) || canCreateCustomLinks} 
             />
         </div>
     </>


### PR DESCRIPTION
This pull request refactors the `AuthContext` and related components to improve the handling of user permissions and mandates. It introduces a new `PermissionObject` type, replaces `userMandates` with `mandateGroups`, and simplifies permission checks. These changes aim to enhance code clarity and maintainability while aligning with updated requirements.

### Changes to `AuthContext` and Permission Handling:
* Added a new `PermissionObject` type and updated `userPermissions` to use this type instead of a string array. (`client/src/autherization/AuthContext.tsx`, [client/src/autherization/AuthContext.tsxR12-R28](diffhunk://#diff-1714b678216cdd1edebaaba3879b87a4792d6ac8d33d0d308b147b43c7632be0R12-R28))
* Replaced `userMandates` with `mandateGroups` and introduced a helper function `hasMandateGroup` for checking group membership. (`client/src/autherization/AuthContext.tsx`, [[1]](diffhunk://#diff-1714b678216cdd1edebaaba3879b87a4792d6ac8d33d0d308b147b43c7632be0L32-R48) [[2]](diffhunk://#diff-1714b678216cdd1edebaaba3879b87a4792d6ac8d33d0d308b147b43c7632be0L94-R128)
* Added new boolean properties (`customLinks` and `manageLinks`) to simplify permission checks for creating and managing links. (`client/src/autherization/AuthContext.tsx`, [client/src/autherization/AuthContext.tsxL138-R142](diffhunk://#diff-1714b678216cdd1edebaaba3879b87a4792d6ac8d33d0d308b147b43c7632be0L138-R142))

### Updates to `LinkCreator` Component:
* Replaced `userMandates` with `userGroups` to align with the updated `AuthContext` structure. (`client/src/components/LinkCreator.tsx`, [client/src/components/LinkCreator.tsxL67-R70](diffhunk://#diff-d2501ba9c56cf8b352df67e6f267fe02e0a2466187226d4a04038059c6cf0222L67-R70))
* Updated the group selector logic to use `userGroups` instead of `userMandates`. (`client/src/components/LinkCreator.tsx`, [client/src/components/LinkCreator.tsxL197-R197](diffhunk://#diff-d2501ba9c56cf8b352df67e6f267fe02e0a2466187226d4a04038059c6cf0222L197-R197))
* Adjusted advanced options visibility to depend on `userGroups` and the `customLinks` permission. (`client/src/components/LinkCreator.tsx`, [client/src/components/LinkCreator.tsxL277-R276](diffhunk://#diff-d2501ba9c56cf8b352df67e6f267fe02e0a2466187226d4a04038059c6cf0222L277-R276))

### Changes to the `Home` Component:
* Replaced `isAdmin` and `userMandates` checks with `customLinks`, `manageLinks`, and `mandateGroups` for permission handling. (`client/src/views/Home.tsx`, [[1]](diffhunk://#diff-7bbdd781838f5efef80e0713b750a50bfca8b4315d37f3acdc959eafe5748d42L14-R17) [[2]](diffhunk://#diff-7bbdd781838f5efef80e0713b750a50bfca8b4315d37f3acdc959eafe5748d42L26-R35)
* Updated the `LinkCreator` integration to use `userGroups` and control advanced options visibility accordingly. (`client/src/views/Home.tsx`, [client/src/views/Home.tsxL84-R87](diffhunk://#diff-7bbdd781838f5efef80e0713b750a50bfca8b4315d37f3acdc959eafe5748d42L84-R87))

### Other Adjustments:
* Removed the unused `Mandate` interface from `LinkCreator` and updated corresponding logic. (`client/src/components/LinkCreator.tsx`, [client/src/components/LinkCreator.tsxL27-L32](diffhunk://#diff-d2501ba9c56cf8b352df67e6f267fe02e0a2466187226d4a04038059c6cf0222L27-L32))
* Updated the `AuthData` interface in `authApi.ts` to match the new `PermissionObject` and `mandateGroups` structure. (`client/src/autherization/authApi.ts`, [client/src/autherization/authApi.tsL6-R17](diffhunk://#diff-b861a59ffc6754189ba2bac6c2555e14bf03f3da86678aa76ada3cf0c0fe9a3fL6-R17))…se PermissionObject type, add mandateGroups and related functions, and modify LinkCreator and Home components to accommodate changes in user data structure.