### PR TITLE
Refactor Links component layout: replace Container with Box, enhance …

### DIFF
--- a/client/src/views/Links.tsx
+++ b/client/src/views/Links.tsx
@@ -8,7 +8,6 @@ import {
     Pagination,
     Text,
     Group,
-    Container,
     Badge,
     Box,
     Stack,
@@ -288,7 +287,7 @@ const Links: React.FC = () => {
     return (
         <>
             <Header title="Länkar - Översikt" />
-            <Container>
+            <Box id="content" p="md">
                 <Box mb="md" mt="md">
                     {!hasToken && (
                         <Alert title="Du är inte inloggad" color="blue" mb="md">
@@ -312,6 +311,7 @@ const Links: React.FC = () => {
                             { value: "slug-z-a", label: "Slug (Ö-A)" },
                         ]}
                     />
+                    <Badge mt="md" size="lg">{sortedLinks.length} resultat</Badge>
                 </Box>
 
                 <Box mb="md" mt="md">
@@ -319,71 +319,73 @@ const Links: React.FC = () => {
                         {paginatedLinks.length > 0 ? (
                             paginatedLinks.map((link) => (
                                 <Card key={link.id} withBorder radius="lg" shadow="sm">
-                                    <Group
-                                        style={{ display: "flex", justifyContent: "space-between" }}
-                                        wrap="nowrap" // Ensure items stay on one line
-                                    >
-                                        {/* Text (Slug, URL) on the LEFT */}
-                                        {/* Apply flex: 1 and minWidth: 0 here */}
-                                        <Group gap="sm" justify="flex-start" style={{ flex: 1, minWidth: 0 }} wrap="nowrap">
-                                            <Text fw={500}>{link.slug}</Text>
-                                            <a
-                                                href={link.url}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                title={link.url}
-                                                style={{
-                                                    textDecoration: 'none',
-                                                    color: 'inherit',
-                                                    overflow: 'hidden', // Added to assist truncation within the link
-                                                }}
-                                            >
-                                                <Text truncate>{link.url}</Text>
-                                            </a>
-                                            <Tooltip label="Antal klick" withArrow>
-                                                <Badge leftSection={<IconPointer size={badgeIconSize} />} variant="gradient" style={{ flexShrink: 0 }}>
-                                                    {link.clicks}
-                                                </Badge>
-                                            </Tooltip>
-                                            {/* Valde blå men kan byta */}
-                                            {link.user_id && (
-                                                <Tooltip label="Ägare" withArrow>
-                                                    <Badge
-                                                        leftSection={<IconUser size={badgeIconSize} />}
-                                                        variant="gradient"
-                                                        gradient={{ from: "blue", to: "blue", deg: 0 }}
-                                                        style={{ flexShrink: 0 }}
-                                                    >
-                                                        {link.user_id}
+                                    <Group justify="space-between" align="center" wrap="wrap">
+                                        {/* LEFT: Text and Badges */}
+                                        <Group gap="sm" align="center" wrap="wrap">
+                                            <Group gap="sm" justify="flex-start" style={{ minWidth: 0, flexShrink: 1 }}>
+                                                <Text fw={500} style={{ whiteSpace: 'nowrap' }}>{link.slug}</Text>
+                                                <a
+                                                    href={link.url}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    title={link.url}
+                                                    style={{
+                                                        textDecoration: 'none',
+                                                        color: 'inherit',
+                                                        minWidth: 0,
+                                                        overflow: 'hidden',
+                                                        textOverflow: 'ellipsis',
+                                                        whiteSpace: 'nowrap',
+                                                        maxWidth: '250px', // Optional: you can tweak this based on layout
+                                                    }}
+                                                >
+                                                    <Text truncate>{link.url}</Text>
+                                                </a>
+                                            </Group>
+
+                                            <Group justify="flex-start" gap="xs">
+                                                <Tooltip label="Antal klick" withArrow>
+                                                    <Badge leftSection={<IconPointer size={badgeIconSize} />} variant="gradient">
+                                                        {link.clicks}
                                                     </Badge>
                                                 </Tooltip>
-                                            )}
-                                            {/* Fixade så att gruppnamn inte syns för länkar utan en grupp*/}
-                                            {extractGroupName(link.group_name) !== "null" && (
-                                                <Tooltip label="Grupp" withArrow>
-                                                    <Badge
-                                                        leftSection={<IconUsersGroup size={badgeIconSize} />}
-                                                        variant="gradient"
-                                                        gradient={{ from: stringToHexColor(link.group_name), to: stringToHexColor(link.group_name, 1.4) }}
-                                                        style={{ flexShrink: 0 }}
-                                                    >
-                                                        {extractGroupName(link.group_name)}
-                                                    </Badge>
-                                                </Tooltip>
-                                            )}
+                                                {link.user_id && (
+                                                    <Tooltip label="Ägare" withArrow>
+                                                        <Badge
+                                                            leftSection={<IconUser size={badgeIconSize} />}
+                                                            variant="gradient"
+                                                            gradient={{ from: "blue", to: "blue", deg: 0 }}
+                                                        >
+                                                            {link.user_id}
+                                                        </Badge>
+                                                    </Tooltip>
+                                                )}
+                                                {extractGroupName(link.group_name) !== "null" && (
+                                                    <Tooltip label="Grupp" withArrow>
+                                                        <Badge
+                                                            leftSection={<IconUsersGroup size={badgeIconSize} />}
+                                                            variant="gradient"
+                                                            gradient={{
+                                                                from: stringToHexColor(link.group_name),
+                                                                to: stringToHexColor(link.group_name, 1.4),
+                                                            }}
+                                                        >
+                                                            {extractGroupName(link.group_name)}
+                                                        </Badge>
+                                                    </Tooltip>
+                                                )}
+                                            </Group>
                                         </Group>
 
-                                        {/* Buttons on the RIGHT */}
-                                        <Group gap="xs" justify="flex-end" style={{ flexShrink: 0 }}> {/* Prevent buttons from shrinking */}
+                                        {/* RIGHT: Buttons */}
+                                        <Group gap="xs" justify="flex-end" style={{ flexShrink: 0 }}>
                                             <Tooltip label="Se detaljer" withArrow>
                                                 <Button
                                                     size="sm"
                                                     variant="filled"
                                                     radius="md"
                                                     onClick={() => handleShowDetails(link.slug)}
-                                                    onMouseEnter={() =>
-                                                        setHoveredDetailsLinkSlug(link.slug)
-                                                    }
+                                                    onMouseEnter={() => setHoveredDetailsLinkSlug(link.slug)}
                                                     onMouseLeave={() => setHoveredDetailsLinkSlug(null)}
                                                 >
                                                     {hoveredDetailsLinkSlug === link.slug ? (
@@ -432,9 +434,7 @@ const Links: React.FC = () => {
                                                     color="red"
                                                     radius="md"
                                                     onClick={() => handleRemove(link.slug)}
-                                                    onMouseEnter={() =>
-                                                        setHoveredRemoveLinkSlug(link.slug)
-                                                    }
+                                                    onMouseEnter={() => setHoveredRemoveLinkSlug(link.slug)}
                                                     onMouseLeave={() => setHoveredRemoveLinkSlug(null)}
                                                 >
                                                     {hoveredRemoveLinkSlug === link.slug ? (
@@ -468,7 +468,7 @@ const Links: React.FC = () => {
                         />
                     )}
                 </Box>
-            </Container>
+            </Box>
         </>
     );
 };


### PR DESCRIPTION
…badge display for click count, and improve text truncation for URLs.

This pull request refactors the `Links` component in `client/src/views/Links.tsx` to improve layout consistency, enhance user experience, and simplify the code. Key changes include replacing the `Container` component with `Box`, improving the layout of badges, and refining the structure of the `Group` components for better responsiveness and readability.

### Layout and Component Updates:
* Replaced the `Container` component with `Box` for more flexible layout control, including adding padding and consistent spacing (`id="content" p="md"`) [[1]](diffhunk://#diff-59b83ce8a7c6bbbe44391bf6cdfcb3cab1d8d54291040168470613f0627316c4L291-R290) [[2]](diffhunk://#diff-59b83ce8a7c6bbbe44391bf6cdfcb3cab1d8d54291040168470613f0627316c4L471-R471).
* Added a badge displaying the total number of sorted links (`<Badge mt="md" size="lg">`) for improved user feedback.

### Improved Responsiveness and Readability:
* Updated `Group` components to better handle wrapping and alignment, ensuring elements like text, badges, and buttons are displayed consistently across different screen sizes (`justify="space-between"`, `wrap="wrap"`) [[1]](diffhunk://#diff-59b83ce8a7c6bbbe44391bf6cdfcb3cab1d8d54291040168470613f0627316c4R314-R326) [[2]](diffhunk://#diff-59b83ce8a7c6bbbe44391bf6cdfcb3cab1d8d54291040168470613f0627316c4L338-R388).
* Adjusted styles for text and links to prevent overflow and ensure proper truncation (`textOverflow: 'ellipsis'`, `whiteSpace: 'nowrap'`, `maxWidth: '250px'`).

### Code Simplification:
* Removed unnecessary inline styles and redundant comments to streamline the codebase [[1]](diffhunk://#diff-59b83ce8a7c6bbbe44391bf6cdfcb3cab1d8d54291040168470613f0627316c4L338-R388) [[2]](diffhunk://#diff-59b83ce8a7c6bbbe44391bf6cdfcb3cab1d8d54291040168470613f0627316c4L435-R437).
* Refactored mouse event handlers for buttons to use single-line arrow functions for cleaner syntax.